### PR TITLE
bump upload/artifact gh-action version to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build HTML Assets
         run: myst build --html
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           path: './_build/html'
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
This seems a Myst Markdown config (`myst init --gh-pages`), but trying to manually bump upload artfiact GitHub action to v4 as per this notice: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/